### PR TITLE
Fix invalid example class in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ or
 ```
 class Foo
     include Sync_m
-    :
 end
 ```
 


### PR DESCRIPTION
Hi 👋 

Was the `:` intentional here? Pretty sure it's invalid Ruby.